### PR TITLE
Add teacher-only Admin Mode for activity registration changes

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
+from typing import Optional
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +21,13 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Teacher credentials and sessions
+teachers_file = current_dir / "teachers.json"
+with open(teachers_file, "r", encoding="utf-8") as f:
+    teacher_accounts = json.load(f)
+
+active_teacher_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -78,6 +88,25 @@ activities = {
 }
 
 
+def get_teacher_by_username(username: str):
+    for teacher in teacher_accounts.get("teachers", []):
+        if teacher.get("username") == username:
+            return teacher
+    return None
+
+
+def get_current_teacher(authorization: Optional[str]) -> str:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Teacher login required")
+
+    token = authorization.split(" ", 1)[1]
+    teacher_username = active_teacher_sessions.get(token)
+    if not teacher_username:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    return teacher_username
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,9 +117,30 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def teacher_login(username: str, password: str):
+    teacher = get_teacher_by_username(username)
+    if not teacher or teacher.get("password") != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    active_teacher_sessions[token] = username
+    return {"message": "Login successful", "token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def teacher_logout(authorization: Optional[str] = Header(default=None)):
+    teacher_username = get_current_teacher(authorization)
+    token = authorization.split(" ", 1)[1]
+    active_teacher_sessions.pop(token, None)
+    return {"message": f"Logged out {teacher_username}"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, authorization: Optional[str] = Header(default=None)):
     """Sign up a student for an activity"""
+    get_current_teacher(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +161,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, authorization: Optional[str] = Header(default=None)):
     """Unregister a student from an activity"""
+    get_current_teacher(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,61 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupLockMessage = document.getElementById("signup-lock-message");
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const userMenu = document.getElementById("user-menu");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const authStatus = document.getElementById("auth-status");
+
+  let teacherToken = localStorage.getItem("teacherToken") || "";
+  let teacherUsername = localStorage.getItem("teacherUsername") || "";
+
+  function isTeacherLoggedIn() {
+    return teacherToken !== "";
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    if (isTeacherLoggedIn()) {
+      authStatus.textContent = `Teacher mode: ${teacherUsername}`;
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      signupForm.classList.remove("hidden");
+      signupLockMessage.classList.add("hidden");
+    } else {
+      authStatus.textContent = "Student view";
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      signupForm.classList.add("hidden");
+      signupLockMessage.classList.remove("hidden");
+    }
+  }
+
+  function getAuthHeaders() {
+    if (!isTeacherLoggedIn()) {
+      return {};
+    }
+    return {
+      Authorization: `Bearer ${teacherToken}`,
+    };
+  }
+
+  function resetActivitySelect() {
+    activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +67,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      resetActivitySelect();
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +86,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacherLoggedIn()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +129,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isTeacherLoggedIn()) {
+      showMessage("Teacher login is required.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,39 +145,104 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
 
+  userMenuBtn.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    userMenu.classList.add("hidden");
+  });
+
+  cancelLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: getAuthHeaders(),
+      });
+    } catch (error) {
+      console.error("Logout request failed:", error);
+    }
+
+    teacherToken = "";
+    teacherUsername = "";
+    localStorage.removeItem("teacherToken");
+    localStorage.removeItem("teacherUsername");
+    updateAuthUI();
+    userMenu.classList.add("hidden");
+    fetchActivities();
+    showMessage("Logged out", "info");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value.trim();
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        {
+          method: "POST",
+        }
+      );
+
+      const result = await response.json();
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      teacherToken = result.token;
+      teacherUsername = result.username;
+      localStorage.setItem("teacherToken", teacherToken);
+      localStorage.setItem("teacherUsername", teacherUsername);
+
+      loginModal.classList.add("hidden");
+      loginForm.reset();
+      updateAuthUI();
+      fetchActivities();
+      showMessage(`Welcome, ${teacherUsername}`, "success");
+    } catch (error) {
+      showMessage("Login failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!isTeacherLoggedIn()) {
+      showMessage("Teacher login is required.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +254,28 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
+  updateAuthUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,16 @@
   </head>
   <body>
     <header>
+      <div class="auth-toolbar">
+        <button id="user-menu-btn" class="icon-btn" aria-label="User menu">👤</button>
+        <div id="user-menu" class="user-menu hidden">
+          <button id="login-btn" type="button">Teacher Login</button>
+          <button id="logout-btn" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <p id="auth-status" class="auth-status">Student view</p>
     </header>
 
     <main>
@@ -23,6 +31,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="signup-lock-message" class="info hidden">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +55,26 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="password" />
+          </div>
+          <div class="modal-actions">
+            <button type="button" id="cancel-login-btn" class="secondary-btn">Cancel</button>
+            <button type="submit">Login</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,49 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.auth-toolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.icon-btn {
+  background-color: white;
+  color: #1a237e;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  font-size: 20px;
+}
+
+.icon-btn:hover {
+  background-color: #e8eaf6;
+}
+
+.user-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  padding: 10px;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 20;
+}
+
+.auth-status {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #c5cae9;
 }
 
 main {
@@ -164,6 +208,14 @@ button:hover {
   background-color: #3949ab;
 }
 
+.secondary-btn {
+  background-color: #6b7280;
+}
+
+.secondary-btn:hover {
+  background-color: #4b5563;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -190,6 +242,35 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  width: 90%;
+  max-width: 420px;
+}
+
+.modal-content h3 {
+  color: #1a237e;
+  margin-bottom: 12px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "mergington123"
+    },
+    {
+      "username": "coach.lee",
+      "password": "soccer-2026"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements issue #5 by introducing a minimal teacher login flow and restricting registration mutations to logged-in teachers.

## Changes
- Add backend teacher auth endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
- Protect mutation endpoints with Bearer token requirement:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Add static teacher credentials file checked by backend:
  - `src/teachers.json`
- Add frontend auth UX:
  - User icon in header
  - Login/logout menu
  - Login modal (username/password)
  - Teacher vs Student status indicator
- Restrict UI actions:
  - Students can view participants only
  - Signup form and unregister buttons are available only in teacher mode

## Notes
- This follows the issue scope of no account-maintenance page and JSON-backed credentials.
- Existing activity viewing flow remains available to all users.

Closes #5